### PR TITLE
bug fix for Android

### DIFF
--- a/Assets/Scripts/Controllers/MainGameController.cs
+++ b/Assets/Scripts/Controllers/MainGameController.cs
@@ -8,20 +8,7 @@ public delegate IEnumerator CoroutineMethod();
 
 public class MainGameController : MonoBehaviour {
 	
-	ControllerInterface[] controllers = new ControllerInterface[]{						
-		new ActiveColorButtonController(),
-		new ActiveToolController(),
-		new UndoRedoController(),
-		new ToolButtonsController(),	
-		new MainColorSelectController(),
-		new WindowPictureController(),
-		new WindowInfoController(),			
-		new WindowColorPickerController(),
-		new WindowStampController(),
-		new WindowSoundController(),
-		new LanguageController(),
-		new SnowThemeController()
-	};	
+	ControllerInterface[] controllers;
 
 	ControllerUpdateInterface[] updateControllers = new ControllerUpdateInterface[]{
 		new WrongActionController()
@@ -47,6 +34,20 @@ public class MainGameController : MonoBehaviour {
 	}
 	
 	void initControllers(){		
+		controllers = new ControllerInterface[]{						
+			new ActiveColorButtonController(),
+			new ActiveToolController(),
+			new UndoRedoController(),
+			new ToolButtonsController(),	
+			new MainColorSelectController(),
+			new WindowPictureController(),
+			new WindowInfoController(),			
+			new WindowColorPickerController(),
+			new WindowStampController(),
+			new WindowSoundController(),
+			new LanguageController(),
+			new SnowThemeController()
+		};	
 		for (int i=0; i< controllers.Length;i++){
 			controllers[i].init();
 		}

--- a/Assets/Scripts/ui/ScreenSizeControllers/ScreenSizeController.cs
+++ b/Assets/Scripts/ui/ScreenSizeControllers/ScreenSizeController.cs
@@ -52,11 +52,13 @@ public class ScreenSizeController : MonoBehaviour {
 	void scaleScreenAndSendEvent () {
 		Debug2.LogDebug("scaleScreenAndSendEvent ");
 		float ratio;
-		Resolution maxRes= Screen.resolutions[Screen.resolutions.Length-1];
-		if (Screen.fullScreen)
+		Resolution maxRes = new Resolution();
+		if (Screen.fullScreen) {
+			maxRes = Screen.resolutions [Screen.resolutions.Length - 1];
 			ratio = (float)maxRes.width / (float)maxRes.height;
-		else
+		} else
 			ratio = (float)Screen.width / (float)Screen.height;
+
 		float normalRatio = PropertiesSingleton.instance.screen.normalAspect;
 		IntVector2 newResolution;
 		if (ratio < normalRatio){


### PR DESCRIPTION
For some reason `controllers` is not initialized when accessed from `void initControllers()` in **MainGameController.cs**

While in windowed mode `Screen.resolutions[Screen.resolutions.Length-1];` is throwing an index out of bound exception in **ScreenSizeController.cs**, I have no idea why the game stars in windowed mode in the first place switching to fullscreen afterwards.